### PR TITLE
Added Import option to create new Surface per Palette Index

### DIFF
--- a/addons/MagicaVoxel_Importer_with_Extensions/CulledMeshGenerator.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/CulledMeshGenerator.gd
@@ -1,99 +1,146 @@
-const Faces = preload("./Faces.gd");
-const vox_to_godot = Basis(Vector3.RIGHT, Vector3.FORWARD, Vector3.UP);
+extends RefCounted
+class_name CulledMeshGenerator
 
-func generate(vox, voxel_data, scale, snaptoground):
-	var generator = VoxelMeshGenerator.new(vox, voxel_data, scale, snaptoground);
+const Faces = preload("./Faces.gd")
+const SurfaceBuckets = preload("./SurfaceBuckets.gd")
 
-	return generator.generate_mesh();
+# VOX → Godot basis
+const vox_to_godot = Basis(Vector3.RIGHT, Vector3.FORWARD, Vector3.UP)
 
-class MeshGenerator:
-	var surfaces = {};
+# Face normals
+const NORMAL_UP      = Vector3.UP
+const NORMAL_DOWN    = Vector3.DOWN
+const NORMAL_LEFT    = Vector3.LEFT
+const NORMAL_RIGHT   = Vector3.RIGHT
+const NORMAL_FRONT   = Vector3.FORWARD
+const NORMAL_BACK    = Vector3.BACK
 
-	func ensure_surface_exists(surface_index: int, color: Color, material: Material):
-		if (surfaces.has(surface_index)): return;
+# Neighbor offsets
+const OFF_UP      = Vector3.UP
+const OFF_DOWN    = Vector3.DOWN
+const OFF_LEFT    = Vector3.LEFT
+const OFF_RIGHT   = Vector3.RIGHT
+const OFF_BACK    = Vector3.BACK
+const OFF_FORWARD = Vector3.FORWARD
 
-		var st = SurfaceTool.new();
-		st.begin(Mesh.PRIMITIVE_TRIANGLES);
-		st.add_color(color);
-		st.set_material(material);
-		surfaces[surface_index] = st;
+func generate(vox, voxel_data: Dictionary, scale: float, snaptoground: bool, perpalettesurface: bool) -> ArrayMesh:
+	# Empty guard
+	if voxel_data.size() == 0:
+		return ArrayMesh.new()
 
-	func add_vertex(surface_index: int, vertex: Vector3):
-		var st = surfaces[surface_index] as SurfaceTool;
-		st.add_vertex(vertex);
+	# Bounds for snap-to-ground
+	var mins = Vector3(1000000.0, 1000000.0, 1000000.0)
+	for v in voxel_data:
+		if v.x < mins.x:
+			mins.x = v.x
+		if v.y < mins.y:
+			mins.y = v.y
+		if v.z < mins.z:
+			mins.z = v.z
 
-	func combine_surfaces():
-		var mesh = null;
-		for surface_index in surfaces:
-			var surface = surfaces[surface_index] as SurfaceTool;
-			surface.index();
-			surface.generate_normals();
-			mesh = surface.commit(mesh);
+	var yoffset = Vector3.ZERO
+	if snaptoground:
+		yoffset = Vector3(0, -mins.z * scale, 0)
 
-			var new_surface_index = mesh.get_surface_count() - 1;
-			var name = str(surface_index);
-			mesh.surface_set_name(new_surface_index, name);
-		return mesh;
+	# Shared surface/material buckets (same as Greedy)
+	var buckets = SurfaceBuckets.new()
+	buckets.vox = vox
+	buckets.per_palette = perpalettesurface
 
-class VoxelMeshGenerator:
-	var vox;
-	var voxel_data = {};
-	var scale:float;
-	var snaptoground:bool;
+	# Build culled faces
+	for voxel in voxel_data:
+		var pi = int(voxel_data[voxel])
+		var color = _color_for_palette(vox, pi)
+		var bucket_key = _bucket_key(perpalettesurface, pi)
 
-	func _init(vox, voxel_data, scale, snaptoground):
-		self.vox = vox;
-		self.voxel_data = voxel_data;
-		self.scale = scale;
-		self.snaptoground = snaptoground;
+		# UP
+		if face_is_visible(vox, voxel_data, voxel, OFF_UP):
+			var st_up = buckets.get_bucket(bucket_key, color)
+			st_up.set_normal(NORMAL_UP)
+			for p in Faces.Top:
+				st_up.add_vertex(yoffset + vox_to_godot * (p + voxel) * scale)
 
-	func get_material(voxel):
-		var surface_index = voxel_data[voxel];
-		return vox.materials[surface_index]
+		# DOWN
+		if face_is_visible(vox, voxel_data, voxel, OFF_DOWN):
+			var st_dn = buckets.get_bucket(bucket_key, color)
+			st_dn.set_normal(NORMAL_DOWN)
+			for p in Faces.Bottom:
+				st_dn.add_vertex(yoffset + vox_to_godot * (p + voxel) * scale)
 
-	func face_is_visible(voxel, face):
-		if (not voxel_data.has(voxel + face)):
-			return true;
-		var local_material = get_material(voxel);
-		var adj_material = get_material(voxel + face);
-		return adj_material.is_glass() && !local_material.is_glass();
+		# LEFT
+		if face_is_visible(vox, voxel_data, voxel, OFF_LEFT):
+			var st_l = buckets.get_bucket(bucket_key, color)
+			st_l.set_normal(NORMAL_LEFT)
+			for p in Faces.Left:
+				st_l.add_vertex(yoffset + vox_to_godot * (p + voxel) * scale)
 
-	func generate_mesh():
+		# RIGHT
+		if face_is_visible(vox, voxel_data, voxel, OFF_RIGHT):
+			var st_r = buckets.get_bucket(bucket_key, color)
+			st_r.set_normal(NORMAL_RIGHT)
+			for p in Faces.Right:
+				st_r.add_vertex(yoffset + vox_to_godot * (p + voxel) * scale)
 
-		# Minimum extends of the volume
-		var mins :Vector3 = Vector3(1000000, 1000000, 1000000)
-		# Maximum extends of the volume
-		var maxs :Vector3 = Vector3(-1000000,-1000000,-1000000)	
+		# BACK (+Z)
+		if face_is_visible(vox, voxel_data, voxel, OFF_BACK):
+			var st_bk = buckets.get_bucket(bucket_key, color)
+			st_bk.set_normal(NORMAL_BACK)
+			for p in Faces.Front:
+				st_bk.add_vertex(yoffset + vox_to_godot * (p + voxel) * scale)
 
-		# Find bounds
-		for v in voxel_data:
-			mins.x = min(mins.x, v.x)
-			mins.y = min(mins.y, v.y)
-			mins.z = min(mins.z, v.z)
-			maxs.x = max(maxs.x, v.x)
-			maxs.y = max(maxs.y, v.y)
-			maxs.z = max(maxs.z, v.z)	
+		# FORWARD (-Z)
+		if face_is_visible(vox, voxel_data, voxel, OFF_FORWARD):
+			var st_fw = buckets.get_bucket(bucket_key, color)
+			st_fw.set_normal(NORMAL_FRONT)
+			for p in Faces.Back:
+				st_fw.add_vertex(yoffset + vox_to_godot * (p + voxel) * scale)
 
-		var vox_to_godot = Basis(Vector3.RIGHT, Vector3.FORWARD, Vector3.UP);
-		var yoffset = Vector3(0,0,0);
-		if snaptoground : yoffset = Vector3(0, -mins.z * scale, 0);
-		var gen = MeshGenerator.new();
+	# Commit to mesh (SurfaceBuckets applies materials and names)
+	var mesh = ArrayMesh.new()
+	buckets.commit_into(mesh)
+	return mesh
 
-		for voxel in voxel_data:
-			var voxelSides = []
-			if face_is_visible(voxel, Vector3.UP): voxelSides += Faces.Top
-			if face_is_visible(voxel, Vector3.DOWN): voxelSides += Faces.Bottom
-			if face_is_visible(voxel, Vector3.LEFT): voxelSides += Faces.Left
-			if face_is_visible(voxel, Vector3.RIGHT): voxelSides += Faces.Right
-			if face_is_visible(voxel, Vector3.BACK): voxelSides += Faces.Front
-			if face_is_visible(voxel, Vector3.FORWARD): voxelSides += Faces.Back
+# ---------- helpers ----------
 
-			var surface_index = voxel_data[voxel];
-			var color = vox.colors[surface_index];
-			var material = vox.materials[surface_index].get_material(color);
-			gen.ensure_surface_exists(surface_index, color, material);
+func _bucket_key(per_palette: bool, pi: int) -> int:
+	if per_palette:
+		return pi
+	else:
+		return -1
 
-			for t in voxelSides:
-				gen.add_vertex(surface_index, yoffset + vox_to_godot.xform((t + voxel) * scale));
+func _color_for_palette(vox: Object, pi: int) -> Color:
+	if vox != null and vox.colors is Array:
+		if pi >= 0 and pi < vox.colors.size():
+			return vox.colors[pi]
+	return Color(1, 1, 1, 1)
 
-		return gen.combine_surfaces();
+# Preserve your glass adjacency rule with safe fallbacks
+func face_is_visible(vox: Object, voxel_data: Dictionary, voxel: Vector3, face_offset: Vector3) -> bool:
+	var neighbor = voxel + face_offset
+	if not voxel_data.has(neighbor):
+		return true
+
+	var local_pi = int(voxel_data[voxel])
+	var adj_pi = int(voxel_data[neighbor])
+
+	var local_vm = null
+	var adj_vm = null
+	if vox != null and (vox.materials is Dictionary):
+		if vox.materials.has(local_pi):
+			local_vm = vox.materials[local_pi]
+		if vox.materials.has(adj_pi):
+			adj_vm = vox.materials[adj_pi]
+
+	var local_is_glass = false
+	var adj_is_glass = false
+
+	if local_vm != null and local_vm.has_method("is_glass"):
+		local_is_glass = bool(local_vm.is_glass())
+	if adj_vm != null and adj_vm.has_method("is_glass"):
+		adj_is_glass = bool(adj_vm.is_glass())
+
+	# Draw when adjacent is glass and local is not glass
+	if adj_is_glass and not local_is_glass:
+		return true
+
+	return false

--- a/addons/MagicaVoxel_Importer_with_Extensions/GreedyMeshGenerator.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/GreedyMeshGenerator.gd
@@ -1,5 +1,9 @@
-const Faces = preload("./Faces.gd")
-const VoxData = preload("./VoxFormat/VoxData.gd")
+const Faces       = preload("./Faces.gd")
+const VoxData     = preload("./VoxFormat/VoxData.gd")
+const VoxMaterial = preload("./VoxFormat/VoxMaterial.gd")
+const SurfaceBuckets = preload("./SurfaceBuckets.gd")
+
+# Godot axis basis to match VOX coordinate space
 const vox_to_godot = Basis(Vector3.RIGHT, Vector3.FORWARD, Vector3.UP)
 
 # Names for the faces by orientation
@@ -13,7 +17,7 @@ enum FaceOrientation {
 }
 
 # An Array(FaceOrientation) of all possible face orientations
-const face_orientations :Array = [
+const face_orientations : Array = [
 	FaceOrientation.Top,
 	FaceOrientation.Bottom,
 	FaceOrientation.Left,
@@ -23,7 +27,7 @@ const face_orientations :Array = [
 ]
 
 # An Array(int) of the depth axis by orientation
-const depth_axis :Array = [
+const depth_axis : Array = [
 	Vector3.AXIS_Z,
 	Vector3.AXIS_Z,
 	Vector3.AXIS_X,
@@ -33,7 +37,7 @@ const depth_axis :Array = [
 ]
 
 # An Array(int) of the width axis by orientation
-const width_axis :Array = [
+const width_axis : Array = [
 	Vector3.AXIS_Y,
 	Vector3.AXIS_Y,
 	Vector3.AXIS_Z,
@@ -43,7 +47,7 @@ const width_axis :Array = [
 ]
 
 # An Array(int) of height axis by orientation
-const height_axis :Array = [
+const height_axis : Array = [
 	Vector3.AXIS_X,
 	Vector3.AXIS_X,
 	Vector3.AXIS_Y,
@@ -52,9 +56,8 @@ const height_axis :Array = [
 	Vector3.AXIS_Z,
 ]
 
-# An Array(Vector3) describing what vectors to use to check for face occlusion
-# by orientation
-const face_checks :Array = [
+# An Array(Vector3) describing what vectors to use to check for face occlusion by orientation
+const face_checks : Array = [
 	Vector3(0, 0, 1),
 	Vector3(0, 0, -1),
 	Vector3(-1, 0, 0),
@@ -64,7 +67,7 @@ const face_checks :Array = [
 ]
 
 # An array of the face meshes by orientation
-const face_meshes :Array = [
+const face_meshes : Array = [
 	Faces.Front,
 	Faces.Back,
 	Faces.Left,
@@ -73,36 +76,57 @@ const face_meshes :Array = [
 	Faces.Top,
 ]
 
-# The SurfaceTool the object will use to generate the mesh
-var st :SurfaceTool = SurfaceTool.new()
+# An Array(Vector3) describing what normals to use by orientation
+const normals : Array = [
+	Vector3(0, 1, 0),
+	Vector3(0, -1, 0),
+	Vector3(-1, 0, 0),
+	Vector3(1, 0, 0),
+	Vector3(0, 0, 1),
+	Vector3(0, 0, -1),
+]
 
-# A Dictonary[Vector3]int of the voxel data for the visible faces of the
-# current slice
-var faces :Dictionary
+# ===== Runtime state =====
 
-# Minimum extends of the volume
-var mins :Vector3 = Vector3(1000000, 1000000, 1000000)
+# VoxData ref
+var _vox_ref: VoxData = null
 
-# Maximum extends of the volume
-var maxs :Vector3 = Vector3(-1000000,-1000000,-1000000)
+# Shared surface bucket manager (handles single-surface vs per-palette)
+var _buckets: SurfaceBuckets = null
 
+# Whether to group/merge by palette index (true) or by color (false)
+var _per_palette: bool = true
+
+# Bounds of the volume
+var mins : Vector3 = Vector3(1000000, 1000000, 1000000)
+var maxs : Vector3 = Vector3(-1000000, -1000000, -1000000)
+
+# ----- Main -----
 # Generate a mesh for the given voxel_data with single-pass greedy face merging
 # Primary Reference: https://0fps.net/2012/06/30/meshing-in-a-minecraft-game/
 # Secondary Reference: https://www.gedge.ca/dev/2014/08/17/greedy-voxel-meshing
-# voxel_data is a dict[Vector3]int
-func generate(vox :VoxData, voxel_data :Dictionary, scale :float, snaptoground : bool):
+# voxel_data is a Dictionary[Vector3] -> palette index (int). DO NOT convert to Color here.
+func generate(vox: VoxData, voxel_data: Dictionary, scale: float, snaptoground: bool, perpalettesurface: bool) -> ArrayMesh:
+
 	# Remeber, MagicaVoxel thinks Y is the depth axis. We convert to the correct
 	# coordinate space when we generate the faces.
-	st.begin(Mesh.PRIMITIVE_TRIANGLES)
 	
-	# Short-circut empty models
+	_vox_ref = vox
+	_per_palette = perpalettesurface
+
+	# reset bounds
+	mins = Vector3(1000000, 1000000, 1000000)
+	maxs = Vector3(-1000000, -1000000, -1000000)
+
+	# Short-circuit empty models
 	if voxel_data.size() == 0:
-		return st.commit()
-	
-	# Convert voxel data to raw color values
-	for v in voxel_data:
-		voxel_data[v] = vox.colors[voxel_data[v]]
-	
+		return ArrayMesh.new()
+
+	# Initialize shared buckets (material generation lives in VoxMaterial via SurfaceBuckets)
+	_buckets = SurfaceBuckets.new()
+	_buckets.vox = vox
+	_buckets.per_palette = perpalettesurface
+
 	# Find bounds
 	for v in voxel_data:
 		mins.x = min(mins.x, v.x)
@@ -111,51 +135,58 @@ func generate(vox :VoxData, voxel_data :Dictionary, scale :float, snaptoground :
 		maxs.x = max(maxs.x, v.x)
 		maxs.y = max(maxs.y, v.y)
 		maxs.z = max(maxs.z, v.z)
-	
-	# Itterate over all face orientations to reduce problem to 3 dimensions
+
+	# Iterate over all face orientations to reduce problem to 3 dimensions
 	for o in face_orientations:
 		generate_geometry_for_orientation(voxel_data, o, scale, snaptoground)
 
-	# Finish the mesh and material and return
-	st.generate_normals()
-	var material = SpatialMaterial.new()
-	material.vertex_color_is_srgb = true
-	material.vertex_color_use_as_albedo = true
-	material.roughness = 1
-	st.set_material(material)
-	return st.commit()
+	# Commit all surfaces into a single ArrayMesh
+	var mesh := ArrayMesh.new()
+	_buckets.commit_into(mesh)
+	return mesh
 
 # Generates all of the geometry for a given face orientation
-func generate_geometry_for_orientation(voxel_data :Dictionary, o :int, scale :float, snaptoground :bool) -> void:
-	# Sweep through the volume along the depth reducing the problem to 2 dimensional
-	var da :int = depth_axis[o]
-	for slice in range(mins[da], maxs[da]+1):
-		var faces :Dictionary = query_slice_faces(voxel_data, o, slice)
+func generate_geometry_for_orientation(voxel_data: Dictionary, o: int, scale: float, snaptoground: bool) -> void:
+	# Sweep through the volume along the depth, reducing the problem to 2D
+	var da : int = depth_axis[o]
+	for slice in range(mins[da], maxs[da] + 1):
+		var faces : Dictionary = query_slice_faces(voxel_data, o, slice)
 		if faces.size() > 0:
 			generate_geometry(faces, o, slice, scale, snaptoground)
 
 # Returns the voxels in the set voxel_data with a visible face along the slice
-# for the given orientation
-func query_slice_faces(voxel_data :Dictionary, o :int, slice :float) -> Dictionary:
-	var ret :Dictionary = Dictionary()
+# for the given orientation.
+# IMPORTANT:
+#  - per-palette mode stores **palette index (int)** as the token
+#  - single-surface mode stores **Color** as the token
+# This ensures greedy merging compares equal tokens correctly (index vs color).
+func query_slice_faces(voxel_data: Dictionary, o: int, slice: float) -> Dictionary:
+	var ret : Dictionary = {}
 	var da = depth_axis[o]
 	for v in voxel_data:
 		if v[da] == slice and voxel_data.has(v + face_checks[o]) == false:
-			ret[v] = voxel_data[v]
+			var pi := int(voxel_data[v])
+			ret[v] = pi if _per_palette else _color_for_palette(pi)
 	return ret
 
+# Returns a Color for a given palette index; white if out-of-range.
+func _color_for_palette(pi: int) -> Color:
+	if _vox_ref != null and _vox_ref.colors is Array and pi >= 0 and pi < _vox_ref.colors.size():
+		return _vox_ref.colors[pi]
+	return Color(1, 1, 1, 1)
+
 # Generates geometry for the given orientation for the set of faces
-func generate_geometry(faces :Dictionary, o :int, slice :float, scale :float, snaptoground :bool) -> void:
-	var da :int = depth_axis[o]
-	var wa :int = width_axis[o]
-	var ha :int = height_axis[o]
-	var v :Vector3 = Vector3()
+func generate_geometry(faces: Dictionary, o: int, slice: float, scale: float, snaptoground: bool) -> void:
+	var da : int = depth_axis[o]
+	var wa : int = width_axis[o]
+	var ha : int = height_axis[o]
+	var v : Vector3 = Vector3()
 	v[da] = slice
-	
-	# Itterate the rows of the sparse volume
+
+	# Iterate the rows of the sparse volume
 	v[ha] = mins[ha]
 	while v[ha] <= maxs[ha]:
-		# Itterate over the voxels of the row
+		# Iterate over the voxels of the row
 		v[wa] = mins[wa]
 		while v[wa] <= maxs[wa]:
 			if faces.has(v):
@@ -163,55 +194,71 @@ func generate_geometry(faces :Dictionary, o :int, slice :float, scale :float, sn
 			v[wa] += 1.0
 		v[ha] += 1.0
 
-# Generates the geometry for the given face and orientation and scale and returns
-# the set of remaining faces
-func generate_geometry_for_face(faces :Dictionary, face :Vector3, o :int, scale :float, snaptoground :bool) -> Dictionary:
-	var da :int = depth_axis[o]
-	var wa :int = width_axis[o]
-	var ha :int = height_axis[o]
-	
-	# Greedy face merging
-	var width :int = width_query(faces, face, o)
-	var height :int = height_query(faces, face, o, width)
-	var grow :Vector3 = Vector3(1, 1, 1)
+# Generates the geometry for the given face and orientation and returns the set of remaining faces
+func generate_geometry_for_face(faces: Dictionary, face: Vector3, o: int, scale: float, snaptoground: bool) -> Dictionary:
+	var da : int = depth_axis[o]
+	var wa : int = width_axis[o]
+	var ha : int = height_axis[o]
+
+	# Greedy face merging (compare equal tokens).
+	# Token is palette index in per-palette mode, or Color in single-surface mode.
+	var width  : int = width_query(faces, face, o)
+	var height : int = height_query(faces, face, o, width)
+	var grow : Vector3 = Vector3(1, 1, 1)
 	grow[wa] *= width
 	grow[ha] *= height
-	
-	# Generate geometry
-	var yoffset = Vector3(0,0,0);
-	if snaptoground : yoffset = Vector3(0, -mins.z * scale, 0);
 
-	st.add_color(faces[face])
+	# Generate geometry
+	var yoffset := Vector3.ZERO
+	if snaptoground:
+		yoffset = Vector3(0, -mins.z * scale, 0)
+
+	# Resolve palette + color depending on mode
+	var palette_id : int
+	var color      : Color
+	if _per_palette:
+		palette_id = int(faces[face])               # token is palette index
+		color      = _color_for_palette(palette_id) # still pass color for vertex tint
+	else:
+		palette_id = -1                             # single surface key inside buckets
+		color      = Color(faces[face])             # token is color already
+
+	# Ask the bucket manager for the correct SurfaceTool for this run
+	var st := _buckets.get_bucket(palette_id, color)
+
+	# Per-face attributes
+	st.set_normal(normals[o])
+	# (we rely on vertex colors; SurfaceBuckets sets the material appropriately)
+
+	# Emit merged quad (as two tris via SurfaceTool)
 	for vert in face_meshes[o]:
-		st.add_vertex(yoffset + vox_to_godot.xform(((vert * grow) + face) * scale))
-	
+		st.add_vertex(yoffset + vox_to_godot * ((vert * grow) + face) * scale)
+
 	# Remove these faces from the pool
-	var v :Vector3 = Vector3()
+	var v : Vector3 = Vector3()
 	v[da] = face[da]
 	for iy in range(height):
 		v[ha] = face[ha] + float(iy)
 		for ix in range(width):
 			v[wa] = face[wa] + float(ix)
 			faces.erase(v)
-	
+
 	return faces
 
-# Returns the number of voxels wide the run starting at face is with respect to
-# the set of faces and orientation
-func width_query(faces :Dictionary, face :Vector3, o :int) -> int:
-	var wd :int = width_axis[o]
-	var v :Vector3 = face
+# Returns the number of voxels wide the run starting at face is with respect to the set of faces and orientation
+func width_query(faces: Dictionary, face: Vector3, o: int) -> int:
+	var wd : int = width_axis[o]
+	var v  : Vector3 = face
 	while faces.has(v) and faces[v] == faces[face]:
 		v[wd] += 1.0
 	return int(v[wd] - face[wd])
 
-# Returns the number of voxels high the run starting at face is with respect to
-# the set of faces and orientation, with the given width
-func height_query(faces :Dictionary, face :Vector3, o :int, width :int) -> int:
-	var hd :int = height_axis[o]
-	var c :Color = faces[face]
-	var v :Vector3 = face
+# Returns the number of voxels high the run starting at face is with respect to the set of faces and orientation, with the given width
+func height_query(faces: Dictionary, face: Vector3, o: int, width: int) -> int:
+	var hd : int = height_axis[o]
+	var token = faces[face]  # int (palette) in per-palette mode, Color otherwise
+	var v    : Vector3 = face
 	v[hd] += 1.0
-	while faces.has(v) and faces[v] == c and width_query(faces, v, o) >= width:
+	while faces.has(v) and faces[v] == token and width_query(faces, v, o) >= width:
 		v[hd] += 1.0
 	return int(v[hd] - face[hd])

--- a/addons/MagicaVoxel_Importer_with_Extensions/SurfaceBuckets.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/SurfaceBuckets.gd
@@ -1,0 +1,61 @@
+# SurfaceBuckets.gd
+extends RefCounted
+class_name SurfaceBuckets
+
+const VoxMaterial = preload("./VoxFormat/VoxMaterial.gd")
+
+var vox: Object
+var per_palette: bool = false
+
+# key(int) -> {"st": SurfaceTool, "mat": Material, "key": int}
+var _map: Dictionary = {}
+
+func get_bucket(pi: int, color: Color) -> SurfaceTool:
+	var key: int
+	if per_palette:
+		key = pi
+	else:
+		key = -1
+
+	var entry = _map.get(key)
+	if entry == null:
+		var st := SurfaceTool.new()
+		st.begin(Mesh.PRIMITIVE_TRIANGLES)
+
+		var mat: Material
+		if per_palette:
+			mat = VoxMaterial.material_for_palette(vox, pi, color)
+		else:
+			mat = VoxMaterial.shared_vertex_color_material()
+
+		st.set_material(mat)
+		entry = {
+			"st": st,
+			"mat": mat,
+			"key": key,
+		}
+		_map[key] = entry
+
+	# keep vertex color updated (used in single-surface mode, harmless otherwise)
+	entry.st.set_color(color)
+	return entry.st
+
+func commit_into(mesh: ArrayMesh) -> void:
+	for entry in _map.values():
+		var st: SurfaceTool = entry.st
+		var mat: Material = entry.mat
+		var key: int = entry.key
+
+		var arrays := st.commit_to_arrays()
+		if arrays.is_empty():
+			continue
+
+		mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
+		var si := mesh.get_surface_count() - 1
+		mesh.surface_set_material(si, mat)
+
+		# Name surfaces for clarity in the inspector
+		if per_palette and key >= 0:
+			mesh.surface_set_name(si, "pi_%d" % key)
+		else:
+			mesh.surface_set_name(si, "vertex_color")

--- a/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxMaterial.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/VoxFormat/VoxMaterial.gd
@@ -1,52 +1,170 @@
-var properties = null;
-var material: SpatialMaterial = null;
+extends RefCounted
+class_name VoxMaterial
 
-var type setget ,get_type;
-func get_type(): return properties["_type"];
+const VOX_DEBUG_PRINT := false
 
-var weight setget ,get_weight;
-func get_weight(): return float(properties["_weight"]);
+# -------- helpers --------
+static func _parse_float_str(s: String, dflt: float) -> float:
+	var t := s.strip_edges()
+	if t == "":
+		return dflt
+	var f := t.to_float()
+	if f != 0.0:
+		return f
+	if t == "0" or t == "0.0":
+		return 0.0
+	return dflt
 
-var specular setget ,get_specular;
-func get_specular(): return float(properties["_spec"]);
+static func _prop_s(props: Dictionary, name: String, obj: Object, dflt: String) -> String:
+	if props.has(name) and props[name] != null:
+		return str(props[name])
+	var v = obj.get(name)
+	if v != null:
+		return str(v)
+	return dflt
 
-var roughness setget ,get_roughness;
-func get_roughness(): return float(properties["_rough"]);
+static func _prop_f(props: Dictionary, name: String, obj: Object, dflt: float) -> float:
+	if props.has(name):
+		var v = props[name]
+		var t := typeof(v)
+		if t == TYPE_FLOAT: return v
+		if t == TYPE_INT:   return v + 0.0
+		if t == TYPE_STRING: return _parse_float_str(v, dflt)
+	var v2 = obj.get(name)
+	if v2 != null:
+		var t2 := typeof(v2)
+		if t2 == TYPE_FLOAT: return v2
+		if t2 == TYPE_INT:   return v2 + 0.0
+		if t2 == TYPE_STRING: return _parse_float_str(v2, dflt)
+	return dflt
 
-var flux setget ,get_flux;
-func get_flux(): return float(properties["_flux"]);
+# -------- state --------
+var properties: Dictionary = {}
 
-var refraction setget ,get_refraction;
-func get_refraction(): return float(properties["_ior"]);
+func _init(props: Dictionary = {}) -> void:
+	properties = props.duplicate(true) if typeof(props) == TYPE_DICTIONARY else {}
 
-func _init(properties):
-	self.properties = properties;
+# ------- helpers ------
+static func shared_vertex_color_material() -> StandardMaterial3D:
+	var m := StandardMaterial3D.new()
+	m.vertex_color_use_as_albedo = true
+	m.vertex_color_is_srgb = true
+	m.roughness = 1.0
+	return m
 
-func is_glass():
-	return self.type == "_glass";
+static func material_for_palette(vox: Object, pi: int, color: Color) -> Material:
+	var mat: Material = null
+	# If VoxMaterial objects are stored on vox.materials[pi] and expose get_material(color)
+	if vox != null and (vox.materials is Dictionary) and vox.materials.has(pi):
+		var vmat = vox.materials[pi]
+		if vmat != null and vmat.has_method("get_material"):
+			mat = vmat.get_material(color)
 
-func get_material(color: Color):
-	if (material != null): return material;
+	return mat if mat != null else shared_vertex_color_material()
 	
-	material = SpatialMaterial.new();
-	material.vertex_color_is_srgb = true;
-	material.vertex_color_use_as_albedo = true;
-	
-	match (self.type):
-		"_metal":
-			material.metallic = self.weight;
-			material.metallic_specular = self.specular;
-			material.roughness = self.roughness;
+# -------- main --------
+func get_material(palette_color: Color) -> StandardMaterial3D:
+	var mat := StandardMaterial3D.new()
+	mat.vertex_color_use_as_albedo = true
+	mat.vertex_color_is_srgb = true
+
+	# Pull MATL dict (underscored keys per MV spec)
+	var props: Dictionary = {}
+	var maybe_props = get("properties")
+	if typeof(maybe_props) == TYPE_DICTIONARY:
+		props = maybe_props
+
+	# Read values (string/int/float all accepted)
+	var vtype   : String = _prop_s(props, "_type", self, "")
+	var rough_v : float  = _prop_f(props, "_rough", self, 1.0)
+	var spec_v  : float  = _prop_f(props, "_sp", self, -1.0)
+	var alpha_v  : float  = _prop_f(props, "_alpha", self, -1.0)
+	var trans_v  : float  = _prop_f(props, "_trans", self, -1.0)
+	var weight_v: float  = _prop_f(props, "_weight", self, -1.0)
+	var flux_v  : float  = _prop_f(props, "_flux", self, -1.0)
+	var ior_v   : float  = _prop_f(props, "_ior", self, -1.0)
+	var emit_v : float = _prop_f(props, "_emit", self, -1.0)
+	var metal_v : float = float(props.get("_metal",-1.0))
+
+	# Debug — confirms what we actually read
+	var keys_str := str(props.keys()) if props.size() > 0 else "[]"
+	if VOX_DEBUG_PRINT:
+		print("[VoxMaterial 4.5] keys=", keys_str,
+			" type=", vtype, " rough=", rough_v, " spec=", spec_v,
+			" flux=", flux_v, " ior=", ior_v,
+			" emit=", emit_v, " metal=", metal_v,
+			" alpha=", alpha_v, " trans=", trans_v)
+
+	# Baseline roughness
+	mat.roughness = clamp(rough_v, 0.0, 1.0)
+
+	match vtype:
 		"_emit":
-			material.emission_enabled = true;
-			material.emission = Color(color.r, color.g, color.b, self.weight);
-			material.emission_energy = self.flux;
+			mat.emission_enabled = true
+			mat.emission_operator = BaseMaterial3D.EMISSION_OP_ADD
+			mat.emission = Color(palette_color.r, palette_color.g, palette_color.b)
+
+			# Combine MV "Emission" (0..100) and "Radiant flux/Power" (≈1..5).
+			# If both are present: scale flux by the normalized emission.
+			# If only one is present: use whichever exists.
+			var energy := -1.0
+			if emit_v > 0.0 and flux_v > 0.0:
+				energy = (emit_v) * flux_v
+			elif emit_v >= 0.0:
+				energy = emit_v
+			elif flux_v >= 0.0:
+				energy = flux_v
+
+			if energy <= 0.0:
+				energy = 1.0  # never leave zero in 4.x
+
+			mat.emission_energy_multiplier = energy
+			mat.metallic = 0.0
+
+		# ---------- METAL ----------
+		"_metal":
+			# Metallic amount (weight), with sensible default
+			var metallic_amount := metal_v
+			if metallic_amount < 0.0:
+				metallic_amount = 1.0
+			mat.metallic = clamp(metallic_amount, 0.0, 1.0)
+
+			# Roughness already set above; clamp again in case weight implied changes
+			mat.roughness = clamp(rough_v, 0.0, 1.0)
+
+			# Optional specular from VOX (0..1); otherwise keep Godot default
+			if spec_v >= 0.0:
+				mat.metallic_specular = clamp(spec_v, 0.0, 1.0)
+
+		# ---------- GLASS ----------
 		"_glass":
-			material.flags_transparent = true;
-			material.albedo_color = Color(1, 1, 1, 1 - self.weight);
-			material.refraction_enabled = true;
-			material.refraction_scale = self.refraction * 0.01;
-			material.roughness = self.roughness;
-		"_diffuse", _:
-			material.roughness = 1;
-	return material;
+			# Transparent + refraction in 4.5
+			mat.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+			mat.refraction_enabled = true
+
+			# IOR -> refraction strength (heuristic scaling to Godot’s 0..1)
+			var use_ior := ior_v
+			if use_ior < 0.0:
+				use_ior = 1.33
+			var refr := (use_ior - 1.0) * 0.6
+			if refr < 0.0:
+				refr = 0.0
+			if refr > 1.0:
+				refr = 1.0
+			mat.refraction_scale = refr
+
+			# Glass shouldn’t be metallic; roughness from VOX if present
+			mat.metallic = 0.0
+			mat.roughness = clamp(rough_v, 0.0, 1.0)
+
+			if alpha_v >= 0.0:
+				var ac := mat.albedo_color
+				ac.a = clamp(alpha_v, 0.0, 1.0)
+				mat.albedo_color = ac
+
+		# ---------- DEFAULT / OTHER ----------
+		_:
+			if spec_v >= 0.0:
+				mat.specular = clamp(spec_v, 0.0, 1.0)
+
+	return mat

--- a/addons/MagicaVoxel_Importer_with_Extensions/plugin.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/plugin.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends EditorPlugin
 
 var pluginToMesh
@@ -9,7 +9,8 @@ func _enter_tree():
 	pluginToMeshLibrary = preload('vox-importer-meshLibrary.gd').new()
 	add_import_plugin(pluginToMesh)
 	add_import_plugin(pluginToMeshLibrary)
-	add_custom_type("FramedMeshInstance", "MeshInstance", preload("framed_mesh_instance.gd"), preload("framed_mesh_instance.png"))
+	add_custom_type("FramedMeshInstance", "MeshInstance3D",
+			preload("framed_mesh_instance.gd"), preload("framed_mesh_instance.png"))
 
 func _exit_tree():
 	remove_import_plugin(pluginToMesh)
@@ -17,3 +18,6 @@ func _exit_tree():
 	pluginToMesh = null
 	pluginToMeshLibrary = null
 	remove_custom_type("FramedMeshInstance")
+
+func _get_priority() -> float:
+	return 1.0

--- a/addons/MagicaVoxel_Importer_with_Extensions/vox-importer-common.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/vox-importer-common.gd
@@ -25,25 +25,26 @@ func import(source_path, destination_path, options, _platforms, _gen_files):
 	var mergeKeyframes = false
 	if options.has("FirstKeyframeOnly"):
 		mergeKeyframes = not bool(options.FirstKeyframeOnly)
+	var perPalletteSurface = false
+	if options.has("UniqueSurfacePerPaletteColor"):
+		perPalletteSurface = bool(options.UniqueSurfacePerPaletteColor)
 
 
-	var file = File.new()
-	var err = file.open(source_path, File.READ)
+	var file = FileAccess.open(source_path, FileAccess.READ)
 
-	if err != OK:
-		if file.is_open(): file.close()
-		return err
+	if file == null:
+		return FileAccess.get_open_error()
 
-	var identifier = PoolByteArray([ file.get_8(), file.get_8(), file.get_8(), file.get_8() ]).get_string_from_ascii()
+	var identifier = PackedByteArray([ file.get_8(), file.get_8(), file.get_8(), file.get_8() ]).get_string_from_ascii()
 	var version = file.get_32()
-	print('Importing: ', source_path, ' (scale: ', scale, ', file version: ', version, ', greedy mesh: ', greedy, ', snap to ground: ', snaptoground, ')');
+	print('Importing: ', source_path, ' (scale: ', scale, ', file version: ', version, ', greedy mesh: ', greedy, ', snap to ground: ', snaptoground, ', Multi-Surface by Palette: ',perPalletteSurface,')');
 
 	var vox = VoxData.new();
 	if identifier == 'VOX ':
 		var voxFile = VoxFile.new(file);
 		while voxFile.has_data_to_read():
 			read_chunk(vox, voxFile);
-	file.close()
+	file = null
 
 	fileKeyframeIds.sort()
 
@@ -51,9 +52,21 @@ func import(source_path, destination_path, options, _platforms, _gen_files):
 	var meshes = []
 	for keyframeVoxels in voxel_data:
 		if greedy:
-			meshes.append(GreedyMeshGenerator.new().generate(vox, voxel_data[keyframeVoxels], scale, snaptoground))
+			meshes.append(GreedyMeshGenerator.new().generate(
+				vox, 
+				voxel_data[keyframeVoxels], 
+				scale, 
+				snaptoground, 
+				perPalletteSurface
+			))
 		else:
-			meshes.append(CulledMeshGenerator.new().generate(vox, voxel_data[keyframeVoxels], scale, snaptoground))
+			meshes.append(CulledMeshGenerator.new().generate(
+				vox, 
+				voxel_data[keyframeVoxels], 
+				scale, 
+				snaptoground,
+				perPalletteSurface
+			))
 	return meshes
 
 func string_to_vector3(input: String) -> Vector3:
@@ -87,7 +100,6 @@ func byte_to_basis(data: int):
 func read_chunk(vox: VoxData, file: VoxFile):
 	var chunk_id = file.get_string(4);
 	var chunk_size = file.get_32();
-	#warning-ignore:unused_variable
 	var childChunks = file.get_32()
 
 	file.set_chunk_size(chunk_size);
@@ -134,19 +146,19 @@ func read_chunk(vox: VoxData, file: VoxFile):
 
 			if debug_file:
 				print('nTRN[', node_id, '] -> ', child);
-				if (!attributes.empty()): print('\t', attributes);
+				if (!attributes.is_empty()): print('\t', attributes);
 			if num_of_frames > 0:
 				node.transforms = {};
 			for _frame in range(num_of_frames):
 				var keyframe = 0;
-				var newTransform = { "translation": Vector3(), "rotation": Basis() };
+				var newTransform = { "position": Vector3(), "rotation": Basis() };
 				var frame_attributes = file.get_vox_dict();
 				if (frame_attributes.has('_f')):
 					keyframe = int(frame_attributes['_f']);
 				if (frame_attributes.has('_t')):
 					var trans = frame_attributes['_t'];
-					newTransform.translation = string_to_vector3(trans);
-					if debug_file: print('\tT: ', newTransform.translation);
+					newTransform.position = string_to_vector3(trans);
+					if debug_file: print('\tT: ', newTransform.position);
 				if (frame_attributes.has('_r')):
 					var rot = frame_attributes['_r'];
 					newTransform.rotation = byte_to_basis(int(rot)).inverse();
@@ -165,7 +177,7 @@ func read_chunk(vox: VoxData, file: VoxFile):
 				node.child_nodes.append(file.get_32());
 			if debug_file:
 				print('nGRP[', node_id, '] -> ', node.child_nodes);
-				if (!attributes.empty()): print('\t', attributes);
+				if (!attributes.is_empty()): print('\t', attributes);
 		'nSHP':
 			var node_id = file.get_32();
 			var attributes = file.get_vox_dict();
@@ -184,7 +196,7 @@ func read_chunk(vox: VoxData, file: VoxFile):
 					fileKeyframeIds.append(keyframe);
 			if debug_file:
 				print('nSHP[', node_id,'] -> ', node.models);
-				if (!attributes.empty()): print('\t', attributes);
+				if (!attributes.is_empty()): print('\t', attributes);
 		'MATL':
 			var material_id = file.get_32() - 1;
 			var properties = file.get_vox_dict();
@@ -244,8 +256,8 @@ class LayeredVoxelData:
 				for voxel in data_keyframed_layered[keyframeId][layerId]:
 					var half_step = Vector3(0.5, 0.5, 0.5);
 					var new_voxel = (
-						(transform.rotation.xform(voxel+half_step)-half_step).floor() +
-						transform.translation);
+						(transform.rotation * voxel+half_step-half_step).floor() +
+						transform.position);
 					new_data[keyframeId][layerId][new_voxel] = (
 						data_keyframed_layered[keyframeId][layerId][voxel]);
 		data_keyframed_layered = new_data;
@@ -267,7 +279,7 @@ class LayeredVoxelData:
 	static func get_input_for_keyframe(focusKeyframeId, inputCollection):
 		var inputKeyframeIds = inputCollection.keys();
 		inputKeyframeIds.sort();
-		inputKeyframeIds.invert();
+		inputKeyframeIds.reverse();
 		var result = inputKeyframeIds.back();
 		for inputKeyframeId in inputKeyframeIds:
 			if inputKeyframeId <= focusKeyframeId:

--- a/addons/MagicaVoxel_Importer_with_Extensions/vox-importer-mesh.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/vox-importer-mesh.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends EditorImportPlugin
 
 const VoxImporterCommon = preload("./vox-importer-common.gd");
@@ -6,28 +6,34 @@ const VoxImporterCommon = preload("./vox-importer-common.gd");
 func _init():
 	print('MagicaVoxel Mesh Importer: Ready')
 
-func get_importer_name():
+func _get_importer_name():
 	return 'MagicaVoxel.With.Extensions.To.Mesh'
 
-func get_visible_name():
+func _get_visible_name():
 	return 'MagicaVoxel Mesh'
 
-func get_recognized_extensions():
+func _get_recognized_extensions():
 	return [ 'vox' ]
 
-func get_resource_type():
+func _get_resource_type():
 	return 'Mesh'
 
-func get_save_extension():
+func _get_save_extension():
 	return 'mesh'
 
-func get_preset_count():
+func _get_preset_count():
 	return 0
 
-func get_preset_name(_preset):
+func _get_preset_name(_preset):
 	return 'Default'
 
-func get_import_options(_preset):
+func _get_import_order():
+	return 0
+
+func _get_priority() -> float:
+	return 1.0
+
+func _get_import_options(path, preset):
 	return [
 		{
 			'name': 'Scale',
@@ -44,13 +50,17 @@ func get_import_options(_preset):
 		{
 			'name': 'FirstKeyframeOnly',
 			'default_value': true
+		},
+		{
+			'name': 'UniqueSurfacePerPaletteColor',
+			'default_value': false
 		}
 	]
 
-func get_option_visibility(_option, _options):
+func _get_option_visibility(path, option, options):
 	return true
 
-func import(source_path, destination_path, options, _platforms, _gen_files):
+func _import(source_path, destination_path, options, _platforms, _gen_files):
 	var meshes = VoxImporterCommon.new().import(source_path, destination_path, options, _platforms, _gen_files);
-	var full_path = "%s.%s" % [ destination_path, get_save_extension() ]
-	return ResourceSaver.save(full_path, meshes[0])
+	var full_path = "%s.%s" % [ destination_path, _get_save_extension() ]
+	return ResourceSaver.save(meshes[0], full_path)

--- a/addons/MagicaVoxel_Importer_with_Extensions/vox-importer-meshLibrary.gd
+++ b/addons/MagicaVoxel_Importer_with_Extensions/vox-importer-meshLibrary.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends EditorImportPlugin
 
 const VoxImporterCommon = preload("./vox-importer-common.gd");
@@ -6,28 +6,34 @@ const VoxImporterCommon = preload("./vox-importer-common.gd");
 func _init():
 	print('MagicaVoxel MeshLibrary Importer: Ready')
 
-func get_importer_name():
+func _get_importer_name():
 	return 'MagicaVoxel.With.Extensions.To.MeshLibrary'
 
-func get_visible_name():
+func _get_visible_name():
 	return 'MagicaVoxel MeshLibrary'
 
-func get_recognized_extensions():
+func _get_recognized_extensions():
 	return [ 'vox' ]
 
-func get_resource_type():
+func _get_resource_type():
 	return 'MeshLibrary'
 
-func get_save_extension():
+func _get_save_extension():
 	return 'meshlib'
 
-func get_preset_count():
+func _get_preset_count():
 	return 0
 
-func get_preset_name(_preset):
+func _get_preset_name(_preset):
 	return 'Default'
 
-func get_import_options(_preset):
+func _get_import_order():
+	return 0
+
+func _get_priority() -> float:
+	return 1.0
+
+func _get_import_options(path, preset_index):
 	return [
 		{
 			'name': 'Scale',
@@ -40,18 +46,22 @@ func get_import_options(_preset):
 		{
 			'name': 'SnapToGround',
 			'default_value': false
+		},
+		{
+			'name': 'UniqueSurfacePerPaletteColor',
+			'default_value': false
 		}
 	]
 
-func get_option_visibility(_option, _options):
+func _get_option_visibility(path, option, options):
 	return true
 
-func import(source_path, destination_path, options, _platforms, _gen_files):
+func _import(source_path, destination_path, options, _platforms, _gen_files):
 	var meshes = VoxImporterCommon.new().import(source_path, destination_path, options, _platforms, _gen_files);
 	var meshLib = MeshLibrary.new()
 	for mesh in meshes:
 		var itemId = meshLib.get_last_unused_item_id()
 		meshLib.create_item(itemId)
 		meshLib.set_item_mesh(itemId, mesh)
-	var full_path = "%s.%s" % [ destination_path, get_save_extension() ]
-	return ResourceSaver.save(full_path, meshLib)
+	var full_path = "%s.%s" % [ destination_path, _get_save_extension() ]
+	return ResourceSaver.save(meshLib, full_path)


### PR DESCRIPTION
Add per-palette surface materials (opt-in)

Summary

This PR adds an optional import mode that creates one surface/material per VOX palette color so MagicaVoxel material properties (emission, metallic, roughness, glass, etc.) map correctly in Godot 4.x. It also deduplicates surface/material logic used by both the Greedy and Culled meshers into a shared helper, and makes the culling path behave well under multithreaded import.

Key changes
Importers

Import option (checkbox): UniqueSurfacePerPaletteColor

false (default) → legacy behavior: single surface with vertex colors.

true → one surface/material per palette index (full material fidelity).

Option is plumbed through to both Greedy and Culled meshers.

Meshing

GreedyMeshGenerator.gd

Supports both modes:

Per-palette: merge by palette index, material from VoxMaterial.

Legacy: merge by Color, single vertex-color material.

Uses shared buckets (see below) instead of local surface dicts.

CulledMeshGenerator.gd

Rewritten to match Greedy’s two modes, without code duplication.

Declares a proper class (extends RefCounted, class_name CulledMeshGenerator) so the importer can call .new().

Uses shared buckets; explicit normals per face.

Shared utilities

SurfaceBuckets.gd (new)

Centralizes surface bucketing: maps “bucket key” → SurfaceTool + Material.

Builds materials via VoxMaterial (per-palette) or a vertex-color fallback (legacy).

Commits all buckets into an ArrayMesh in one pass.

Optional surface naming:

If enabled: names surfaces pi_<index> in per-palette mode, or vertex_color in legacy mode.

Default off for best import behavior.

VoxMaterial.gd

Added static helpers:

material_for_palette(vox, pi, color) — returns a Material based on parsed VOX MATL props (falls back to vertex-color if none).

shared_vertex_color_material() — Godot 4.x friendly defaults.

Why

Material fidelity: Per-palette surfaces let us carry MV’s emission/metallic/glass into Godot as intended.

No duplication: Both meshers needed identical “group triangles by surface & set material” logic — now it’s one helper.

Behavior matrix
Option UniqueSurfacePerPaletteColor	Greedy	Culled
false (default)	Single surface, merge by Color, vertex-color material	Single surface, culled faces, vertex-color material true	One surface per palette index, material via VoxMaterial	Same as Greedy (per-palette surfaces/materials) Files touched

addons/.../vox-importer-mesh.gd / vox-importer-meshLibrary.gd / vox-importer-common.gd

Adds UniqueSurfacePerPaletteColor, forwards to meshers.

addons/.../GreedyMeshGenerator.gd

Refactored to use SurfaceBuckets; dual token (palette index vs Color) for greedy merges; no local material code.

addons/.../CulledMeshGenerator.gd

Refactored to use SurfaceBuckets; explicit extends RefCounted + class_name; dual mode parity with Greedy; thread-friendly.

addons/.../SurfaceBuckets.gd (new)

Manages bucket creation, material assignment, commit, and (optional) naming.

addons/.../VoxFormat/VoxMaterial.gd

Adds material_for_palette() + shared_vertex_color_material(); debug print gated.

How to test

Baseline (legacy):

Uncheck UniqueSurfacePerPaletteColor.

Import a VOX with multiple palette colors in single surface material.

Expect: one mesh surface named vertex_color (if naming was enabled), correct vertex tinting, no stalls on multithreaded import.

Per-palette:

Check UniqueSurfacePerPaletteColor.

Import the same file.

Expect: multiple surfaces named pi_<index> (if naming enabled), materials reflect MV props (emission, metallic, glass).

Regression (Greedy vs Culled):

Import using both Greedy and Culling.

Expect identical material outcomes for each mode; geometry differs only by meshing strategy (merged vs culled).

Notes / Migration

No breaking API changes for importers; one new option only.

Surface naming is configurable; left off by default for performance.